### PR TITLE
5 build the announcement service for lostfound items

### DIFF
--- a/backend/src/main/java/com/opossum/controller/AnnouncementController.java
+++ b/backend/src/main/java/com/opossum/controller/AnnouncementController.java
@@ -1,0 +1,263 @@
+package com.opossum.controller;
+
+import com.opossum.dto.announcement.AnnouncementDto;
+import com.opossum.dto.announcement.CreateAnnouncementRequest;
+import com.opossum.dto.announcement.UpdateAnnouncementRequest;
+import com.opossum.entity.announcement.AnnouncementStatus;
+import com.opossum.entity.announcement.AnnouncementType;
+import com.opossum.service.AnnouncementService;
+import com.opossum.service.JwtService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+@RestController
+@RequestMapping("/api/announcements")
+@RequiredArgsConstructor
+@Slf4j
+@Tag(name = "Announcements", description = "Lost & Found announcements management")
+public class AnnouncementController {
+
+    private final AnnouncementService announcementService;
+    private final JwtService jwtService;
+
+    @PostMapping
+    @Operation(summary = "Create announcement", description = "Create a new lost or found item announcement")
+    @ApiResponses({
+            @ApiResponse(responseCode = "201", description = "Announcement created successfully"),
+            @ApiResponse(responseCode = "400", description = "Invalid request data"),
+            @ApiResponse(responseCode = "401", description = "Authentication required")
+    })
+    public ResponseEntity<?> createAnnouncement(
+            @Valid @RequestBody CreateAnnouncementRequest request,
+            @RequestHeader("Authorization") String authHeader) {
+
+        try {
+            // Extract user ID from JWT token
+            String token = authHeader.substring(7); // Remove "Bearer "
+            Long userId = jwtService.extractUserId(token);
+
+            AnnouncementDto announcement = announcementService.createAnnouncement(request, userId);
+            return ResponseEntity.status(HttpStatus.CREATED).body(announcement);
+
+        } catch (Exception e) {
+            log.error("Error creating announcement: {}", e.getMessage());
+            return ResponseEntity.badRequest().body(Map.of("error", e.getMessage()));
+        }
+    }
+
+    @GetMapping
+    @Operation(summary = "Get all announcements", description = "Get all active announcements with optional filtering")
+    public ResponseEntity<?> getAllAnnouncements(
+            @Parameter(description = "Filter by announcement type") @RequestParam(required = false) AnnouncementType type,
+            @Parameter(description = "Filter by announcement status") @RequestParam(required = false) AnnouncementStatus status,
+            @Parameter(description = "Filter by category") @RequestParam(required = false) String category,
+            @Parameter(description = "Search in title and description") @RequestParam(required = false) String search) {
+
+        try {
+            List<AnnouncementDto> announcements;
+
+            if (search != null && !search.trim().isEmpty()) {
+                announcements = announcementService.searchAnnouncements(search);
+            } else if (type != null || status != null || category != null) {
+                announcements = announcementService.getAnnouncementsWithFilters(type, status, category);
+            } else {
+                announcements = announcementService.getAllAnnouncements();
+            }
+
+            return ResponseEntity.ok(announcements);
+
+        } catch (Exception e) {
+            log.error("Error getting announcements: {}", e.getMessage());
+            return ResponseEntity.badRequest().body(Map.of("error", e.getMessage()));
+        }
+    }
+
+    @GetMapping("/{id}")
+    @Operation(summary = "Get announcement by ID", description = "Get specific announcement details")
+    public ResponseEntity<?> getAnnouncementById(@PathVariable Long id) {
+        try {
+            Optional<AnnouncementDto> announcement = announcementService.getAnnouncementById(id);
+
+            if (announcement.isPresent()) {
+                return ResponseEntity.ok(announcement.get());
+            } else {
+                return ResponseEntity.notFound().build();
+            }
+
+        } catch (Exception e) {
+            log.error("Error getting announcement by ID {}: {}", id, e.getMessage());
+            return ResponseEntity.badRequest().body(Map.of("error", e.getMessage()));
+        }
+    }
+
+    @GetMapping("/my")
+    @Operation(summary = "Get my announcements", description = "Get current user's announcements")
+    public ResponseEntity<?> getMyAnnouncements(
+            @RequestHeader("Authorization") String authHeader) {
+
+        try {
+            // Extract user ID from JWT token
+            String token = authHeader.substring(7);
+            Long userId = jwtService.extractUserId(token);
+
+            List<AnnouncementDto> announcements = announcementService.getAnnouncementsByUser(userId);
+            return ResponseEntity.ok(announcements);
+
+        } catch (Exception e) {
+            log.error("Error getting user announcements: {}", e.getMessage());
+            return ResponseEntity.badRequest().body(Map.of("error", e.getMessage()));
+        }
+    }
+
+    @PutMapping("/{id}")
+    @Operation(summary = "Update announcement", description = "Update announcement details (owner only)")
+    public ResponseEntity<?> updateAnnouncement(
+            @PathVariable Long id,
+            @Valid @RequestBody UpdateAnnouncementRequest request,
+            @RequestHeader("Authorization") String authHeader) {
+
+        try {
+            // Extract user ID from JWT token
+            String token = authHeader.substring(7);
+            Long userId = jwtService.extractUserId(token);
+
+            AnnouncementDto updatedAnnouncement = announcementService.updateAnnouncement(id, request, userId);
+            return ResponseEntity.ok(updatedAnnouncement);
+
+        } catch (Exception e) {
+            log.error("Error updating announcement {}: {}", id, e.getMessage());
+            return ResponseEntity.badRequest().body(Map.of("error", e.getMessage()));
+        }
+    }
+
+    @PatchMapping("/{id}/status")
+    @Operation(summary = "Update announcement status", description = "Update announcement status (owner only)")
+    public ResponseEntity<?> updateAnnouncementStatus(
+            @PathVariable Long id,
+            @RequestBody Map<String, String> statusUpdate,
+            @RequestHeader("Authorization") String authHeader) {
+
+        try {
+            // Extract user ID from JWT token
+            String token = authHeader.substring(7);
+            Long userId = jwtService.extractUserId(token);
+
+            // Parse status
+            AnnouncementStatus status = AnnouncementStatus.valueOf(statusUpdate.get("status"));
+
+            AnnouncementDto updatedAnnouncement = announcementService.updateAnnouncementStatus(id, status, userId);
+            return ResponseEntity.ok(updatedAnnouncement);
+
+        } catch (Exception e) {
+            log.error("Error updating announcement status {}: {}", id, e.getMessage());
+            return ResponseEntity.badRequest().body(Map.of("error", e.getMessage()));
+        }
+    }
+
+    @DeleteMapping("/{id}")
+    @Operation(summary = "Delete announcement", description = "Delete announcement (owner only)")
+    public ResponseEntity<?> deleteAnnouncement(
+            @PathVariable Long id,
+            @RequestHeader("Authorization") String authHeader) {
+
+        try {
+            // Extract user ID from JWT token
+            String token = authHeader.substring(7);
+            Long userId = jwtService.extractUserId(token);
+
+            announcementService.deleteAnnouncement(id, userId);
+            return ResponseEntity.ok(Map.of("message", "Announcement deleted successfully"));
+
+        } catch (Exception e) {
+            log.error("Error deleting announcement {}: {}", id, e.getMessage());
+            return ResponseEntity.badRequest().body(Map.of("error", e.getMessage()));
+        }
+    }
+
+    @PatchMapping("/{id}/deactivate")
+    @Operation(summary = "Deactivate announcement", description = "Deactivate announcement (owner only)")
+    public ResponseEntity<?> deactivateAnnouncement(
+            @PathVariable Long id,
+            @RequestHeader("Authorization") String authHeader) {
+
+        try {
+            // Extract user ID from JWT token
+            String token = authHeader.substring(7);
+            Long userId = jwtService.extractUserId(token);
+
+            announcementService.deactivateAnnouncement(id, userId);
+            return ResponseEntity.ok(Map.of("message", "Announcement deactivated successfully"));
+
+        } catch (Exception e) {
+            log.error("Error deactivating announcement {}: {}", id, e.getMessage());
+            return ResponseEntity.badRequest().body(Map.of("error", e.getMessage()));
+        }
+    }
+
+    @PatchMapping("/{id}/activate")
+    @Operation(summary = "Activate announcement", description = "Activate announcement (owner only)")
+    public ResponseEntity<?> activateAnnouncement(
+            @PathVariable Long id,
+            @RequestHeader("Authorization") String authHeader) {
+
+        try {
+            // Extract user ID from JWT token
+            String token = authHeader.substring(7);
+            Long userId = jwtService.extractUserId(token);
+
+            announcementService.activateAnnouncement(id, userId);
+            return ResponseEntity.ok(Map.of("message", "Announcement activated successfully"));
+
+        } catch (Exception e) {
+            log.error("Error activating announcement {}: {}", id, e.getMessage());
+            return ResponseEntity.badRequest().body(Map.of("error", e.getMessage()));
+        }
+    }
+
+    @GetMapping("/recent")
+    @Operation(summary = "Get recent announcements", description = "Get most recent announcements")
+    public ResponseEntity<?> getRecentAnnouncements(
+            @Parameter(description = "Number of announcements to return") @RequestParam(defaultValue = "10") int limit) {
+
+        try {
+            List<AnnouncementDto> announcements = announcementService.getRecentAnnouncements(limit);
+            return ResponseEntity.ok(announcements);
+
+        } catch (Exception e) {
+            log.error("Error getting recent announcements: {}", e.getMessage());
+            return ResponseEntity.badRequest().body(Map.of("error", e.getMessage()));
+        }
+    }
+
+    @GetMapping("/stats")
+    @Operation(summary = "Get announcement statistics", description = "Get announcement counts and statistics")
+    public ResponseEntity<?> getAnnouncementStats() {
+        try {
+            Map<String, Object> stats = Map.of(
+                    "total", announcementService.getTotalAnnouncementsCount(),
+                    "lost", announcementService.getAnnouncementsCountByType(AnnouncementType.LOST),
+                    "found", announcementService.getAnnouncementsCountByType(AnnouncementType.FOUND),
+                    "active", announcementService.getAnnouncementsCountByStatus(AnnouncementStatus.ACTIVE),
+                    "resolved", announcementService.getAnnouncementsCountByStatus(AnnouncementStatus.RESOLVED));
+
+            return ResponseEntity.ok(stats);
+
+        } catch (Exception e) {
+            log.error("Error getting announcement stats: {}", e.getMessage());
+            return ResponseEntity.badRequest().body(Map.of("error", e.getMessage()));
+        }
+    }
+}

--- a/backend/src/main/java/com/opossum/controller/AuthController.java
+++ b/backend/src/main/java/com/opossum/controller/AuthController.java
@@ -1,6 +1,12 @@
 package com.opossum.controller;
 
 import com.opossum.dto.*;
+import com.opossum.dto.auth.AuthenticationResponse;
+import com.opossum.dto.auth.ChangePasswordRequest;
+import com.opossum.dto.auth.LoginRequest;
+import com.opossum.dto.auth.RefreshTokenRequest;
+import com.opossum.dto.auth.RegisterRequest;
+import com.opossum.dto.auth.ResetPasswordRequest;
 import com.opossum.service.AuthenticationService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;

--- a/backend/src/main/java/com/opossum/controller/UserController.java
+++ b/backend/src/main/java/com/opossum/controller/UserController.java
@@ -1,7 +1,7 @@
 package com.opossum.controller;
 
-import com.opossum.dto.CreateUserRequest;
 import com.opossum.dto.UserDto;
+import com.opossum.dto.auth.CreateUserRequest;
 import com.opossum.service.UserService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;

--- a/backend/src/main/java/com/opossum/dto/announcement/AnnouncementDto.java
+++ b/backend/src/main/java/com/opossum/dto/announcement/AnnouncementDto.java
@@ -1,0 +1,43 @@
+package com.opossum.dto.announcement;
+
+import com.opossum.entity.announcement.AnnouncementStatus;
+import com.opossum.entity.announcement.AnnouncementType;
+import lombok.Data;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+@Data
+public class AnnouncementDto {
+
+    private Long id;
+    private String title;
+    private String description;
+    private AnnouncementType type;
+    private AnnouncementStatus status;
+    private String category;
+
+    // Location fields
+    private BigDecimal latitude;
+    private BigDecimal longitude;
+    private String address;
+    private Boolean isLocationApproximate;
+
+    // Date fields
+    private LocalDateTime incidentDate;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+
+    // User info
+    private Long userId;
+    private String username;
+    private String userEmail;
+    private String userFullName;
+
+    // Additional fields
+    private String contactInfo;
+    private Boolean isActive;
+
+    // Utility field
+    private String locationDescription;
+}

--- a/backend/src/main/java/com/opossum/dto/announcement/CreateAnnouncementRequest.java
+++ b/backend/src/main/java/com/opossum/dto/announcement/CreateAnnouncementRequest.java
@@ -1,0 +1,44 @@
+package com.opossum.dto.announcement;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.Data;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+import com.opossum.entity.announcement.AnnouncementType;
+
+@Data
+public class CreateAnnouncementRequest {
+
+    @NotBlank(message = "Title is required")
+    @Size(max = 200, message = "Title must not exceed 200 characters")
+    private String title;
+
+    @NotBlank(message = "Description is required")
+    @Size(max = 2000, message = "Description must not exceed 2000 characters")
+    private String description;
+
+    @NotNull(message = "Announcement type is required")
+    private AnnouncementType type;
+
+    @Size(max = 100, message = "Category must not exceed 100 characters")
+    private String category;
+
+    // Location fields
+    private BigDecimal latitude;
+    private BigDecimal longitude;
+
+    @Size(max = 500, message = "Address must not exceed 500 characters")
+    private String address;
+
+    private Boolean isLocationApproximate = false;
+
+    @NotNull(message = "Incident date is required")
+    private LocalDateTime incidentDate;
+
+    @Size(max = 500, message = "Contact info must not exceed 500 characters")
+    private String contactInfo;
+}

--- a/backend/src/main/java/com/opossum/dto/announcement/UpdateAnnouncementRequest.java
+++ b/backend/src/main/java/com/opossum/dto/announcement/UpdateAnnouncementRequest.java
@@ -1,0 +1,37 @@
+package com.opossum.dto.announcement;
+
+import com.opossum.entity.announcement.AnnouncementStatus;
+import jakarta.validation.constraints.Size;
+import lombok.Data;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+@Data
+public class UpdateAnnouncementRequest {
+
+    @Size(max = 200, message = "Title must not exceed 200 characters")
+    private String title;
+
+    @Size(max = 2000, message = "Description must not exceed 2000 characters")
+    private String description;
+
+    private AnnouncementStatus status;
+
+    @Size(max = 100, message = "Category must not exceed 100 characters")
+    private String category;
+
+    // Location fields
+    private BigDecimal latitude;
+    private BigDecimal longitude;
+
+    @Size(max = 500, message = "Address must not exceed 500 characters")
+    private String address;
+
+    private Boolean isLocationApproximate;
+
+    private LocalDateTime incidentDate;
+
+    @Size(max = 500, message = "Contact info must not exceed 500 characters")
+    private String contactInfo;
+}

--- a/backend/src/main/java/com/opossum/dto/auth/AuthenticationResponse.java
+++ b/backend/src/main/java/com/opossum/dto/auth/AuthenticationResponse.java
@@ -1,4 +1,6 @@
-package com.opossum.dto;
+package com.opossum.dto.auth;
+
+import com.opossum.dto.UserDto;
 
 import lombok.AllArgsConstructor;
 import lombok.Data;

--- a/backend/src/main/java/com/opossum/dto/auth/ChangePasswordRequest.java
+++ b/backend/src/main/java/com/opossum/dto/auth/ChangePasswordRequest.java
@@ -1,4 +1,4 @@
-package com.opossum.dto;
+package com.opossum.dto.auth;
 
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;

--- a/backend/src/main/java/com/opossum/dto/auth/CreateUserRequest.java
+++ b/backend/src/main/java/com/opossum/dto/auth/CreateUserRequest.java
@@ -1,4 +1,4 @@
-package com.opossum.dto;
+package com.opossum.dto.auth;
 
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;

--- a/backend/src/main/java/com/opossum/dto/auth/LoginRequest.java
+++ b/backend/src/main/java/com/opossum/dto/auth/LoginRequest.java
@@ -1,4 +1,4 @@
-package com.opossum.dto;
+package com.opossum.dto.auth;
 
 import jakarta.validation.constraints.NotBlank;
 import lombok.AllArgsConstructor;

--- a/backend/src/main/java/com/opossum/dto/auth/RefreshTokenRequest.java
+++ b/backend/src/main/java/com/opossum/dto/auth/RefreshTokenRequest.java
@@ -1,4 +1,4 @@
-package com.opossum.dto;
+package com.opossum.dto.auth;
 
 import jakarta.validation.constraints.NotBlank;
 import lombok.AllArgsConstructor;

--- a/backend/src/main/java/com/opossum/dto/auth/RegisterRequest.java
+++ b/backend/src/main/java/com/opossum/dto/auth/RegisterRequest.java
@@ -1,4 +1,4 @@
-package com.opossum.dto;
+package com.opossum.dto.auth;
 
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;

--- a/backend/src/main/java/com/opossum/dto/auth/ResetPasswordRequest.java
+++ b/backend/src/main/java/com/opossum/dto/auth/ResetPasswordRequest.java
@@ -1,4 +1,4 @@
-package com.opossum.dto;
+package com.opossum.dto.auth;
 
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;

--- a/backend/src/main/java/com/opossum/entity/announcement/Announcement.java
+++ b/backend/src/main/java/com/opossum/entity/announcement/Announcement.java
@@ -1,0 +1,103 @@
+package com.opossum.entity.announcement;
+
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import com.opossum.entity.User;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "ops_announcements")
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class Announcement {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, length = 200)
+    @NotBlank(message = "Title is required")
+    @Size(max = 200, message = "Title must not exceed 200 characters")
+    private String title;
+
+    @Column(nullable = false, length = 2000)
+    @NotBlank(message = "Description is required")
+    @Size(max = 2000, message = "Description must not exceed 2000 characters")
+    private String description;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    @NotNull(message = "Announcement type is required")
+    private AnnouncementType type;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    @NotNull(message = "Announcement status is required")
+    private AnnouncementStatus status = AnnouncementStatus.ACTIVE;
+
+    @Column(length = 100)
+    @Size(max = 100, message = "Category must not exceed 100 characters")
+    private String category;
+
+    // GPS Location fields
+    @Column(precision = 10, scale = 8)
+    private BigDecimal latitude;
+
+    @Column(precision = 11, scale = 8)
+    private BigDecimal longitude;
+
+    @Column(length = 500)
+    @Size(max = 500, message = "Address must not exceed 500 characters")
+    private String address;
+
+    @Column(nullable = false)
+    private Boolean isLocationApproximate = false;
+
+    // Date fields
+    @Column(nullable = false)
+    @NotNull(message = "Incident date is required")
+    private LocalDateTime incidentDate;
+
+    @CreationTimestamp
+    @Column(nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @UpdateTimestamp
+    @Column(nullable = false)
+    private LocalDateTime updatedAt;
+
+    // User relationship
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    @NotNull(message = "User is required")
+    private User user;
+
+    // Additional fields
+    @Column(length = 500)
+    @Size(max = 500, message = "Contact info must not exceed 500 characters")
+    private String contactInfo;
+
+    @Column(nullable = false)
+    private Boolean isActive = true;
+
+    // Utility method
+    public String getLocationDescription() {
+        if (address != null && !address.trim().isEmpty()) {
+            return address;
+        } else if (latitude != null && longitude != null) {
+            return String.format("%.6f, %.6f", latitude, longitude);
+        }
+        return "Location not specified";
+    }
+}

--- a/backend/src/main/java/com/opossum/entity/announcement/AnnouncementStatus.java
+++ b/backend/src/main/java/com/opossum/entity/announcement/AnnouncementStatus.java
@@ -1,0 +1,7 @@
+package com.opossum.entity.announcement;
+
+public enum AnnouncementStatus {
+    ACTIVE,
+    RESOLVED,
+    ARCHIVED
+}

--- a/backend/src/main/java/com/opossum/entity/announcement/AnnouncementType.java
+++ b/backend/src/main/java/com/opossum/entity/announcement/AnnouncementType.java
@@ -1,0 +1,6 @@
+package com.opossum.entity.announcement;
+
+public enum AnnouncementType {
+    LOST,
+    FOUND
+}

--- a/backend/src/main/java/com/opossum/mapper/AnnouncementMapper.java
+++ b/backend/src/main/java/com/opossum/mapper/AnnouncementMapper.java
@@ -1,0 +1,149 @@
+package com.opossum.mapper;
+
+import com.opossum.dto.announcement.AnnouncementDto;
+import com.opossum.dto.announcement.CreateAnnouncementRequest;
+import com.opossum.dto.announcement.UpdateAnnouncementRequest;
+import com.opossum.entity.announcement.Announcement;
+import com.opossum.entity.announcement.AnnouncementStatus;
+import com.opossum.entity.User;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Component
+public class AnnouncementMapper {
+
+    // Convert Entity to DTO
+    public AnnouncementDto toDto(Announcement announcement) {
+        if (announcement == null) {
+            return null;
+        }
+
+        AnnouncementDto dto = new AnnouncementDto();
+        dto.setId(announcement.getId());
+        dto.setTitle(announcement.getTitle());
+        dto.setDescription(announcement.getDescription());
+        dto.setType(announcement.getType());
+        dto.setStatus(announcement.getStatus());
+        dto.setCategory(announcement.getCategory());
+
+        // Location fields
+        dto.setLatitude(announcement.getLatitude());
+        dto.setLongitude(announcement.getLongitude());
+        dto.setAddress(announcement.getAddress());
+        dto.setIsLocationApproximate(announcement.getIsLocationApproximate());
+
+        // Date fields
+        dto.setIncidentDate(announcement.getIncidentDate());
+        dto.setCreatedAt(announcement.getCreatedAt());
+        dto.setUpdatedAt(announcement.getUpdatedAt());
+
+        // User info
+        if (announcement.getUser() != null) {
+            dto.setUserId(announcement.getUser().getId());
+            dto.setUsername(announcement.getUser().getUsername());
+            dto.setUserEmail(announcement.getUser().getEmail());
+            dto.setUserFullName(announcement.getUser().getFullName());
+        }
+
+        // Additional fields
+        dto.setContactInfo(announcement.getContactInfo());
+        dto.setIsActive(announcement.getIsActive());
+
+        // Utility field
+        dto.setLocationDescription(announcement.getLocationDescription());
+
+        return dto;
+    }
+
+    // Convert CreateRequest to Entity
+    public Announcement toEntity(CreateAnnouncementRequest request, User user) {
+        if (request == null) {
+            return null;
+        }
+
+        Announcement announcement = new Announcement();
+        announcement.setTitle(request.getTitle());
+        announcement.setDescription(request.getDescription());
+        announcement.setType(request.getType());
+        announcement.setStatus(AnnouncementStatus.ACTIVE);
+        announcement.setCategory(request.getCategory());
+
+        // Location fields
+        announcement.setLatitude(request.getLatitude());
+        announcement.setLongitude(request.getLongitude());
+        announcement.setAddress(request.getAddress());
+        announcement.setIsLocationApproximate(request.getIsLocationApproximate());
+
+        // Date fields
+        announcement.setIncidentDate(request.getIncidentDate());
+
+        // User relationship
+        announcement.setUser(user);
+
+        // Additional fields
+        announcement.setContactInfo(request.getContactInfo());
+        announcement.setIsActive(true);
+
+        return announcement;
+    }
+
+    // Update Entity from UpdateRequest
+    public void updateEntity(Announcement announcement, UpdateAnnouncementRequest request) {
+        if (announcement == null || request == null) {
+            return;
+        }
+
+        // Only update non-null fields
+        if (request.getTitle() != null) {
+            announcement.setTitle(request.getTitle());
+        }
+        if (request.getDescription() != null) {
+            announcement.setDescription(request.getDescription());
+        }
+        if (request.getStatus() != null) {
+            announcement.setStatus(request.getStatus());
+        }
+        if (request.getCategory() != null) {
+            announcement.setCategory(request.getCategory());
+        }
+
+        // Location fields (allow null to clear location)
+        if (request.getLatitude() != null) {
+            announcement.setLatitude(request.getLatitude());
+        }
+        if (request.getLongitude() != null) {
+            announcement.setLongitude(request.getLongitude());
+        }
+        if (request.getAddress() != null) {
+            announcement.setAddress(request.getAddress());
+        }
+        if (request.getIsLocationApproximate() != null) {
+            announcement.setIsLocationApproximate(request.getIsLocationApproximate());
+        }
+
+        // Date fields
+        if (request.getIncidentDate() != null) {
+            announcement.setIncidentDate(request.getIncidentDate());
+        }
+
+        // Additional fields
+        if (request.getContactInfo() != null) {
+            announcement.setContactInfo(request.getContactInfo());
+        }
+
+        // Updated timestamp will be set automatically by @UpdateTimestamp
+    }
+
+    // Convert List of Entities to List of DTOs
+    public List<AnnouncementDto> toDtoList(List<Announcement> announcements) {
+        if (announcements == null) {
+            return null;
+        }
+
+        return announcements.stream()
+                .map(this::toDto)
+                .collect(Collectors.toList());
+    }
+}

--- a/backend/src/main/java/com/opossum/repository/AnnouncementRepository.java
+++ b/backend/src/main/java/com/opossum/repository/AnnouncementRepository.java
@@ -1,0 +1,84 @@
+package com.opossum.repository;
+
+import com.opossum.entity.announcement.Announcement;
+import com.opossum.entity.announcement.AnnouncementStatus;
+import com.opossum.entity.announcement.AnnouncementType;
+import com.opossum.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Repository
+public interface AnnouncementRepository extends JpaRepository<Announcement, Long> {
+
+        // Find by basic properties
+        List<Announcement> findByType(AnnouncementType type);
+
+        List<Announcement> findByStatus(AnnouncementStatus status);
+
+        List<Announcement> findByTypeAndStatus(AnnouncementType type, AnnouncementStatus status);
+
+        // Find by user
+        List<Announcement> findByUser(User user);
+
+        List<Announcement> findByUserId(Long userId);
+
+        List<Announcement> findByUserIdAndStatus(Long userId, AnnouncementStatus status);
+
+        // Find by category
+        List<Announcement> findByCategory(String category);
+
+        List<Announcement> findByCategoryAndType(String category, AnnouncementType type);
+
+        // Find by active status
+        List<Announcement> findByIsActiveTrue();
+
+        List<Announcement> findByIsActiveTrueAndStatus(AnnouncementStatus status);
+
+        List<Announcement> findByIsActiveTrueAndType(AnnouncementType type);
+
+        // Find by date range
+        List<Announcement> findByCreatedAtBetween(LocalDateTime start, LocalDateTime end);
+
+        List<Announcement> findByIncidentDateBetween(LocalDateTime start, LocalDateTime end);
+
+        // Search by text (title or description)
+        @Query("SELECT a FROM Announcement a WHERE " +
+                        "(LOWER(a.title) LIKE LOWER(CONCAT('%', :searchText, '%')) OR " +
+                        "LOWER(a.description) LIKE LOWER(CONCAT('%', :searchText, '%'))) AND " +
+                        "a.isActive = true")
+        List<Announcement> searchByText(@Param("searchText") String searchText);
+
+        // Search with filters
+        @Query("SELECT a FROM Announcement a WHERE " +
+                        "(:type IS NULL OR a.type = :type) AND " +
+                        "(:status IS NULL OR a.status = :status) AND " +
+                        "(:category IS NULL OR a.category = :category) AND " +
+                        "a.isActive = true " +
+                        "ORDER BY a.createdAt DESC")
+        List<Announcement> findWithFilters(@Param("type") AnnouncementType type,
+                        @Param("status") AnnouncementStatus status,
+                        @Param("category") String category);
+
+        // Count methods
+        long countByType(AnnouncementType type);
+
+        long countByStatus(AnnouncementStatus status);
+
+        long countByUserId(Long userId);
+
+        long countByIsActiveTrue();
+
+        // Order by created date
+        List<Announcement> findByIsActiveTrueOrderByCreatedAtDesc();
+
+        // Recent announcements
+        List<Announcement> findTop10ByIsActiveTrueOrderByCreatedAtDesc();
+
+        // User's recent announcements
+        List<Announcement> findTop5ByUserIdOrderByCreatedAtDesc(Long userId);
+}

--- a/backend/src/main/java/com/opossum/service/AnnouncementService.java
+++ b/backend/src/main/java/com/opossum/service/AnnouncementService.java
@@ -1,0 +1,75 @@
+package com.opossum.service;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import com.opossum.dto.announcement.AnnouncementDto;
+import com.opossum.dto.announcement.CreateAnnouncementRequest;
+import com.opossum.dto.announcement.UpdateAnnouncementRequest;
+import com.opossum.entity.announcement.AnnouncementStatus;
+import com.opossum.entity.announcement.AnnouncementType;
+
+public interface AnnouncementService {
+
+    // Create operations
+    AnnouncementDto createAnnouncement(CreateAnnouncementRequest request, Long userId);
+
+    // Read operations
+    List<AnnouncementDto> getAllAnnouncements();
+
+    Optional<AnnouncementDto> getAnnouncementById(Long id);
+
+    List<AnnouncementDto> getAnnouncementsByUser(Long userId);
+
+    List<AnnouncementDto> getAnnouncementsByType(AnnouncementType type);
+
+    List<AnnouncementDto> getAnnouncementsByStatus(AnnouncementStatus status);
+
+    List<AnnouncementDto> getAnnouncementsByCategory(String category);
+
+    // Update operations
+    AnnouncementDto updateAnnouncement(Long id, UpdateAnnouncementRequest request, Long userId);
+
+    AnnouncementDto updateAnnouncementStatus(Long id, AnnouncementStatus status, Long userId);
+
+    // Delete operations
+    void deleteAnnouncement(Long id, Long userId);
+
+    void deactivateAnnouncement(Long id, Long userId);
+
+    void activateAnnouncement(Long id, Long userId);
+
+    // Search operations
+    List<AnnouncementDto> searchAnnouncements(String searchText);
+
+    List<AnnouncementDto> getAnnouncementsWithFilters(AnnouncementType type,
+            AnnouncementStatus status,
+            String category);
+
+    // Date-based queries
+    List<AnnouncementDto> getAnnouncementsByDateRange(LocalDateTime startDate, LocalDateTime endDate);
+
+    List<AnnouncementDto> getRecentAnnouncements(int limit);
+
+    List<AnnouncementDto> getUserRecentAnnouncements(Long userId, int limit);
+
+    // Statistics
+    long getTotalAnnouncementsCount();
+
+    long getAnnouncementsCountByType(AnnouncementType type);
+
+    long getAnnouncementsCountByStatus(AnnouncementStatus status);
+
+    long getUserAnnouncementsCount(Long userId);
+
+    // Validation operations
+    boolean isAnnouncementOwner(Long announcementId, Long userId);
+
+    // Admin operations
+    List<AnnouncementDto> getAllAnnouncementsForAdmin();
+
+    void adminDeleteAnnouncement(Long id);
+
+    AnnouncementDto adminUpdateAnnouncementStatus(Long id, AnnouncementStatus status);
+}

--- a/backend/src/main/java/com/opossum/service/AuthenticationService.java
+++ b/backend/src/main/java/com/opossum/service/AuthenticationService.java
@@ -1,6 +1,11 @@
 package com.opossum.service;
 
 import com.opossum.dto.*;
+import com.opossum.dto.auth.AuthenticationResponse;
+import com.opossum.dto.auth.ChangePasswordRequest;
+import com.opossum.dto.auth.LoginRequest;
+import com.opossum.dto.auth.RefreshTokenRequest;
+import com.opossum.dto.auth.RegisterRequest;
 import com.opossum.entity.User;
 import com.opossum.mapper.UserMapper;
 import com.opossum.repository.UserRepository;
@@ -97,8 +102,8 @@ public class AuthenticationService {
         User user = userDetailsService.getUserEntity(request.getLogin());
 
         // Generate JWT tokens
-        String accessToken = jwtService.generateToken(userDetails);
-        String refreshToken = jwtService.generateRefreshToken(userDetails);
+        String accessToken = jwtService.generateToken(userDetails, user.getId());
+        String refreshToken = jwtService.generateRefreshToken(userDetails, user.getId());
 
         // Update last login
         user.setLastLogin(LocalDateTime.now());
@@ -136,8 +141,8 @@ public class AuthenticationService {
         }
 
         // Generate new access token
-        String newAccessToken = jwtService.generateToken(userDetails);
         User user = userDetailsService.getUserEntity(username);
+        String newAccessToken = jwtService.generateToken(userDetails, user.getId());
 
         log.info("Access token refreshed for user: {}", username);
 

--- a/backend/src/main/java/com/opossum/service/JwtService.java
+++ b/backend/src/main/java/com/opossum/service/JwtService.java
@@ -43,8 +43,10 @@ public class JwtService {
     }
 
     // Generate token for user with default claims
-    public String generateToken(UserDetails userDetails) {
-        return generateToken(new HashMap<>(), userDetails);
+    public String generateToken(UserDetails userDetails, Long userId) {
+        Map<String, Object> claims = new HashMap<>();
+        claims.put("userId", userId);
+        return buildToken(claims, userDetails, jwtExpiration);
     }
 
     // Generate token with custom claims
@@ -53,8 +55,33 @@ public class JwtService {
     }
 
     // Generate refresh token
-    public String generateRefreshToken(UserDetails userDetails) {
-        return buildToken(new HashMap<>(), userDetails, jwtExpiration * 7); // 7 days expiration for refresh token
+    public String generateRefreshToken(UserDetails userDetails, Long userId) {
+        Map<String, Object> claims = new HashMap<>();
+        claims.put("userId", userId);
+        return buildToken(claims, userDetails, jwtExpiration * 7);
+    }
+
+    // Extract user ID from JWT token
+    public Long extractUserId(String token) {
+        try {
+            Claims claims = extractAllClaims(token);
+            Object userIdClaim = claims.get("userId");
+
+            if (userIdClaim != null) {
+                if (userIdClaim instanceof Integer) {
+                    return ((Integer) userIdClaim).longValue();
+                } else if (userIdClaim instanceof Long) {
+                    return (Long) userIdClaim;
+                } else {
+                    throw new RuntimeException("Invalid userId claim type in token");
+                }
+            } else {
+                throw new RuntimeException("User ID not found in token claims");
+            }
+        } catch (Exception e) {
+            log.error("Error extracting user ID from token: {}", e.getMessage());
+            throw new RuntimeException("Invalid token: cannot extract user ID");
+        }
     }
 
     // Build the actual JWT token

--- a/backend/src/main/java/com/opossum/service/UserService.java
+++ b/backend/src/main/java/com/opossum/service/UserService.java
@@ -1,7 +1,7 @@
 package com.opossum.service;
 
-import com.opossum.dto.CreateUserRequest;
 import com.opossum.dto.UserDto;
+import com.opossum.dto.auth.CreateUserRequest;
 import com.opossum.entity.User;
 
 import java.util.List;

--- a/backend/src/main/java/com/opossum/service/impl/AnnouncementServiceImpl.java
+++ b/backend/src/main/java/com/opossum/service/impl/AnnouncementServiceImpl.java
@@ -1,0 +1,299 @@
+package com.opossum.service.impl;
+
+import com.opossum.dto.announcement.AnnouncementDto;
+import com.opossum.dto.announcement.CreateAnnouncementRequest;
+import com.opossum.dto.announcement.UpdateAnnouncementRequest;
+import com.opossum.entity.announcement.Announcement;
+import com.opossum.entity.announcement.AnnouncementStatus;
+import com.opossum.entity.announcement.AnnouncementType;
+import com.opossum.entity.User;
+import com.opossum.mapper.AnnouncementMapper;
+import com.opossum.repository.AnnouncementRepository;
+import com.opossum.repository.UserRepository;
+import com.opossum.service.AnnouncementService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+@Transactional
+public class AnnouncementServiceImpl implements AnnouncementService {
+
+    private final AnnouncementRepository announcementRepository;
+    private final UserRepository userRepository;
+    private final AnnouncementMapper announcementMapper;
+
+    @Override
+    public AnnouncementDto createAnnouncement(CreateAnnouncementRequest request, Long userId) {
+        log.info("Creating announcement for user ID: {}", userId);
+
+        // Find user
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new RuntimeException("User not found with ID: " + userId));
+
+        // Convert request to entity
+        Announcement announcement = announcementMapper.toEntity(request, user);
+
+        // Save announcement
+        Announcement savedAnnouncement = announcementRepository.save(announcement);
+
+        log.info("Announcement created successfully with ID: {}", savedAnnouncement.getId());
+        return announcementMapper.toDto(savedAnnouncement);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<AnnouncementDto> getAllAnnouncements() {
+        log.debug("Getting all active announcements");
+        List<Announcement> announcements = announcementRepository.findByIsActiveTrueOrderByCreatedAtDesc();
+        return announcementMapper.toDtoList(announcements);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public Optional<AnnouncementDto> getAnnouncementById(Long id) {
+        log.debug("Getting announcement by ID: {}", id);
+        Optional<Announcement> announcement = announcementRepository.findById(id);
+        return announcement.map(announcementMapper::toDto);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<AnnouncementDto> getAnnouncementsByUser(Long userId) {
+        log.debug("Getting announcements for user ID: {}", userId);
+        List<Announcement> announcements = announcementRepository.findByUserId(userId);
+        return announcementMapper.toDtoList(announcements);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<AnnouncementDto> getAnnouncementsByType(AnnouncementType type) {
+        log.debug("Getting announcements by type: {}", type);
+        List<Announcement> announcements = announcementRepository.findByIsActiveTrueAndType(type);
+        return announcementMapper.toDtoList(announcements);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<AnnouncementDto> getAnnouncementsByStatus(AnnouncementStatus status) {
+        log.debug("Getting announcements by status: {}", status);
+        List<Announcement> announcements = announcementRepository.findByIsActiveTrueAndStatus(status);
+        return announcementMapper.toDtoList(announcements);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<AnnouncementDto> getAnnouncementsByCategory(String category) {
+        log.debug("Getting announcements by category: {}", category);
+        List<Announcement> announcements = announcementRepository.findByCategoryAndType(category, null);
+        return announcementMapper.toDtoList(announcements);
+    }
+
+    @Override
+    public AnnouncementDto updateAnnouncement(Long id, UpdateAnnouncementRequest request, Long userId) {
+        log.info("Updating announcement ID: {} by user ID: {}", id, userId);
+
+        // Find announcement
+        Announcement announcement = announcementRepository.findById(id)
+                .orElseThrow(() -> new RuntimeException("Announcement not found with ID: " + id));
+
+        // Check ownership
+        if (!isAnnouncementOwner(id, userId)) {
+            throw new RuntimeException("User not authorized to update this announcement");
+        }
+
+        // Update announcement
+        announcementMapper.updateEntity(announcement, request);
+        Announcement updatedAnnouncement = announcementRepository.save(announcement);
+
+        log.info("Announcement updated successfully with ID: {}", updatedAnnouncement.getId());
+        return announcementMapper.toDto(updatedAnnouncement);
+    }
+
+    @Override
+    public AnnouncementDto updateAnnouncementStatus(Long id, AnnouncementStatus status, Long userId) {
+        log.info("Updating announcement status to {} for ID: {} by user ID: {}", status, id, userId);
+
+        // Find announcement
+        Announcement announcement = announcementRepository.findById(id)
+                .orElseThrow(() -> new RuntimeException("Announcement not found with ID: " + id));
+
+        // Check ownership
+        if (!isAnnouncementOwner(id, userId)) {
+            throw new RuntimeException("User not authorized to update this announcement");
+        }
+
+        // Update status
+        announcement.setStatus(status);
+        Announcement updatedAnnouncement = announcementRepository.save(announcement);
+
+        log.info("Announcement status updated successfully for ID: {}", updatedAnnouncement.getId());
+        return announcementMapper.toDto(updatedAnnouncement);
+    }
+
+    @Override
+    public void deleteAnnouncement(Long id, Long userId) {
+        log.info("Deleting announcement ID: {} by user ID: {}", id, userId);
+
+        // Find announcement
+        Announcement announcement = announcementRepository.findById(id)
+                .orElseThrow(() -> new RuntimeException("Announcement not found with ID: " + id));
+
+        // Check ownership
+        if (!isAnnouncementOwner(id, userId)) {
+            throw new RuntimeException("User not authorized to delete this announcement");
+        }
+
+        // Delete announcement
+        announcementRepository.delete(announcement);
+        log.info("Announcement deleted successfully with ID: {}", id);
+    }
+
+    @Override
+    public void deactivateAnnouncement(Long id, Long userId) {
+        log.info("Deactivating announcement ID: {} by user ID: {}", id, userId);
+
+        // Check ownership first
+        if (!isAnnouncementOwner(id, userId)) {
+            throw new RuntimeException("User not authorized to deactivate this announcement");
+        }
+
+        // Find announcement
+        Announcement announcement = announcementRepository.findById(id)
+                .orElseThrow(() -> new RuntimeException("Announcement not found with ID: " + id));
+
+        // Deactivate announcement
+        announcement.setIsActive(false);
+        announcementRepository.save(announcement);
+        log.info("Announcement deactivated successfully with ID: {}", id);
+    }
+
+    @Override
+    public void activateAnnouncement(Long id, Long userId) {
+        log.info("Activating announcement ID: {} by user ID: {}", id, userId);
+
+        // Find announcement
+        Announcement announcement = announcementRepository.findById(id)
+                .orElseThrow(() -> new RuntimeException("Announcement not found with ID: " + id));
+
+        // Check ownership
+        if (!isAnnouncementOwner(id, userId)) {
+            throw new RuntimeException("User not authorized to update this announcement");
+        }
+
+        // Activate announcement
+        announcement.setIsActive(true);
+        announcementRepository.save(announcement);
+        log.info("Announcement activated successfully with ID: {}", id);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<AnnouncementDto> searchAnnouncements(String searchText) {
+        log.debug("Searching announcements with text: {}", searchText);
+        List<Announcement> announcements = announcementRepository.searchByText(searchText);
+        return announcementMapper.toDtoList(announcements);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<AnnouncementDto> getAnnouncementsWithFilters(AnnouncementType type,
+            AnnouncementStatus status,
+            String category) {
+        log.debug("Getting announcements with filters - type: {}, status: {}, category: {}", type, status, category);
+        List<Announcement> announcements = announcementRepository.findWithFilters(type, status, category);
+        return announcementMapper.toDtoList(announcements);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<AnnouncementDto> getAnnouncementsByDateRange(LocalDateTime startDate, LocalDateTime endDate) {
+        log.debug("Getting announcements by date range: {} to {}", startDate, endDate);
+        List<Announcement> announcements = announcementRepository.findByCreatedAtBetween(startDate, endDate);
+        return announcementMapper.toDtoList(announcements);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<AnnouncementDto> getRecentAnnouncements(int limit) {
+        log.debug("Getting {} recent announcements", limit);
+        List<Announcement> announcements = announcementRepository.findTop10ByIsActiveTrueOrderByCreatedAtDesc();
+        return announcementMapper.toDtoList(announcements.stream().limit(limit).toList());
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<AnnouncementDto> getUserRecentAnnouncements(Long userId, int limit) {
+        log.debug("Getting {} recent announcements for user ID: {}", limit, userId);
+        List<Announcement> announcements = announcementRepository.findTop5ByUserIdOrderByCreatedAtDesc(userId);
+        return announcementMapper.toDtoList(announcements.stream().limit(limit).toList());
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public long getTotalAnnouncementsCount() {
+        return announcementRepository.countByIsActiveTrue();
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public long getAnnouncementsCountByType(AnnouncementType type) {
+        return announcementRepository.countByType(type);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public long getAnnouncementsCountByStatus(AnnouncementStatus status) {
+        return announcementRepository.countByStatus(status);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public long getUserAnnouncementsCount(Long userId) {
+        return announcementRepository.countByUserId(userId);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public boolean isAnnouncementOwner(Long announcementId, Long userId) {
+        Optional<Announcement> announcement = announcementRepository.findById(announcementId);
+        return announcement.isPresent() && announcement.get().getUser().getId().equals(userId);
+    }
+
+    // Admin operations
+    @Override
+    @Transactional(readOnly = true)
+    public List<AnnouncementDto> getAllAnnouncementsForAdmin() {
+        log.debug("Getting all announcements for admin");
+        List<Announcement> announcements = announcementRepository.findAll();
+        return announcementMapper.toDtoList(announcements);
+    }
+
+    @Override
+    public void adminDeleteAnnouncement(Long id) {
+        log.info("Admin deleting announcement ID: {}", id);
+        announcementRepository.deleteById(id);
+        log.info("Announcement deleted by admin with ID: {}", id);
+    }
+
+    @Override
+    public AnnouncementDto adminUpdateAnnouncementStatus(Long id, AnnouncementStatus status) {
+        log.info("Admin updating announcement status to {} for ID: {}", status, id);
+
+        Announcement announcement = announcementRepository.findById(id)
+                .orElseThrow(() -> new RuntimeException("Announcement not found with ID: " + id));
+
+        announcement.setStatus(status);
+        Announcement updatedAnnouncement = announcementRepository.save(announcement);
+
+        log.info("Announcement status updated by admin for ID: {}", updatedAnnouncement.getId());
+        return announcementMapper.toDto(updatedAnnouncement);
+    }
+}

--- a/backend/src/main/java/com/opossum/service/impl/UserServiceImpl.java
+++ b/backend/src/main/java/com/opossum/service/impl/UserServiceImpl.java
@@ -1,7 +1,7 @@
 package com.opossum.service.impl;
 
-import com.opossum.dto.CreateUserRequest;
 import com.opossum.dto.UserDto;
+import com.opossum.dto.auth.CreateUserRequest;
 import com.opossum.entity.User;
 import com.opossum.mapper.UserMapper;
 import com.opossum.repository.UserRepository;

--- a/docs/PostmanCollection/opossum_postman_collection.json
+++ b/docs/PostmanCollection/opossum_postman_collection.json
@@ -487,10 +487,28 @@
       ]
     },
     {
-      "name": "📢 Announcements (Future - Issue #5)",
+      "name": "📢 Announcements",
       "item": [
         {
-          "name": "Create Announcement",
+          "name": "Create Announcement (Lost Item)",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "// Auto-extract announcement ID for future requests",
+                  "if (pm.response.code === 201) {",
+                  "    const response = pm.response.json();",
+                  "    pm.environment.set('announcement_id', response.id);",
+                  "    console.log('✅ Lost item announcement created! ID:', response.id);",
+                  "    console.log('📋 Title:', response.title);",
+                  "} else {",
+                  "    console.log('❌ Failed to create announcement:', pm.response.text());",
+                  "}"
+                ]
+              }
+            }
+          ],
           "request": {
             "method": "POST",
             "header": [
@@ -505,14 +523,40 @@
             ],
             "body": {
               "mode": "raw",
-              "raw": "{\n    \"title\": \"Lost iPhone\",\n    \"description\": \"Lost my iPhone 14 Pro near the train station\",\n    \"type\": \"LOST\",\n    \"category\": \"Electronics\",\n    \"latitude\": 45.7640,\n    \"longitude\": 4.8357,\n    \"address\": \"Gare de Lyon, Paris\",\n    \"incidentDate\": \"2025-07-11T10:30:00\"\n}"
+              "raw": "{\n    \"title\": \"Lost DoDo's iPhone\",\n    \"description\": \"Lost my iPhone 14 Pro near the train station. It has a blue case with stickers.\",\n    \"type\": \"LOST\",\n    \"category\": \"Electronics\",\n    \"latitude\": 45.7640,\n    \"longitude\": 4.8357,\n    \"address\": \"Gare de Lyon, Paris\",\n    \"incidentDate\": \"2025-07-11T10:30:00\",\n    \"contactInfo\": \"Please call me if you find it!\"\n}"
             },
             "url": {
               "raw": "{{base_url}}/api/announcements",
               "host": ["{{base_url}}"],
               "path": ["api", "announcements"]
             },
-            "description": "Create new lost/found announcement."
+            "description": "Create new lost item announcement."
+          }
+        },
+        {
+          "name": "Create Announcement (Found Item)",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "Authorization",
+                "value": "Bearer {{access_token}}"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n    \"title\": \"Found Black Wallet\",\n    \"description\": \"Found a black leather wallet with credit cards and ID near the coffee shop.\",\n    \"type\": \"FOUND\",\n    \"category\": \"Personal Items\",\n    \"latitude\": 45.7642,\n    \"longitude\": 4.8359,\n    \"address\": \"Rue de la République, Lyon\",\n    \"incidentDate\": \"2025-07-11T14:15:00\",\n    \"contactInfo\": \"Contact NoNo to claim your wallet\"\n}"
+            },
+            "url": {
+              "raw": "{{base_url}}/api/announcements",
+              "host": ["{{base_url}}"],
+              "path": ["api", "announcements"]
+            },
+            "description": "Create new found item announcement."
           }
         },
         {
@@ -520,25 +564,75 @@
           "request": {
             "method": "GET",
             "url": {
-              "raw": "{{base_url}}/api/announcements?type=LOST&status=ACTIVE",
+              "raw": "{{base_url}}/api/announcements",
+              "host": ["{{base_url}}"],
+              "path": ["api", "announcements"]
+            },
+            "description": "Get all active announcements without filters."
+          }
+        },
+        {
+          "name": "Get Announcements with Filters",
+          "request": {
+            "method": "GET",
+            "url": {
+              "raw": "{{base_url}}/api/announcements?type=LOST&status=ACTIVE&category=Electronics",
               "host": ["{{base_url}}"],
               "path": ["api", "announcements"],
               "query": [
                 {
                   "key": "type",
-                  "value": "LOST"
+                  "value": "LOST",
+                  "description": "Filter by LOST or FOUND"
                 },
                 {
                   "key": "status",
-                  "value": "ACTIVE"
+                  "value": "ACTIVE",
+                  "description": "Filter by ACTIVE, RESOLVED, ARCHIVED"
+                },
+                {
+                  "key": "category",
+                  "value": "Electronics",
+                  "description": "Filter by category"
                 }
               ]
             },
-            "description": "Get announcements with filtering options."
+            "description": "Get announcements with type, status, and category filters."
+          }
+        },
+        {
+          "name": "Search Announcements",
+          "request": {
+            "method": "GET",
+            "url": {
+              "raw": "{{base_url}}/api/announcements?search=iPhone",
+              "host": ["{{base_url}}"],
+              "path": ["api", "announcements"],
+              "query": [
+                {
+                  "key": "search",
+                  "value": "iPhone",
+                  "description": "Search in title and description"
+                }
+              ]
+            },
+            "description": "Search announcements by text in title and description."
           }
         },
         {
           "name": "Get Announcement by ID",
+          "request": {
+            "method": "GET",
+            "url": {
+              "raw": "{{base_url}}/api/announcements/{{announcement_id}}",
+              "host": ["{{base_url}}"],
+              "path": ["api", "announcements", "{{announcement_id}}"]
+            },
+            "description": "Get specific announcement details by ID."
+          }
+        },
+        {
+          "name": "Get My Announcements",
           "request": {
             "method": "GET",
             "header": [
@@ -548,11 +642,11 @@
               }
             ],
             "url": {
-              "raw": "{{base_url}}/api/announcements/{{announcement_id}}",
+              "raw": "{{base_url}}/api/announcements/my",
               "host": ["{{base_url}}"],
-              "path": ["api", "announcements", "{{announcement_id}}"]
+              "path": ["api", "announcements", "my"]
             },
-            "description": "Get specific announcement details."
+            "description": "Get current user's announcements."
           }
         },
         {
@@ -571,14 +665,135 @@
             ],
             "body": {
               "mode": "raw",
-              "raw": "{\n    \"title\": \"Found iPhone\",\n    \"description\": \"Found iPhone 14 Pro near train station\",\n    \"status\": \"RESOLVED\"\n}"
+              "raw": "{\n    \"title\": \"Lost DoDo's iPhone - URGENT\",\n    \"description\": \"Lost my iPhone 14 Pro near the train station. It has a blue case with stickers. URGENT - contains important photos!\",\n    \"category\": \"Electronics\",\n    \"contactInfo\": \"Please call me ASAP if you find it! Reward offered.\"\n}"
             },
             "url": {
               "raw": "{{base_url}}/api/announcements/{{announcement_id}}",
               "host": ["{{base_url}}"],
               "path": ["api", "announcements", "{{announcement_id}}"]
             },
-            "description": "Update announcement details."
+            "description": "Update announcement details (owner only)."
+          }
+        },
+        {
+          "name": "Update Announcement Status",
+          "request": {
+            "method": "PATCH",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "Authorization",
+                "value": "Bearer {{access_token}}"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n    \"status\": \"RESOLVED\"\n}"
+            },
+            "url": {
+              "raw": "{{base_url}}/api/announcements/{{announcement_id}}/status",
+              "host": ["{{base_url}}"],
+              "path": ["api", "announcements", "{{announcement_id}}", "status"]
+            },
+            "description": "Update announcement status to ACTIVE, RESOLVED, or ARCHIVED."
+          }
+        },
+        {
+          "name": "Deactivate Announcement",
+          "request": {
+            "method": "PATCH",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{access_token}}"
+              }
+            ],
+            "url": {
+              "raw": "{{base_url}}/api/announcements/{{announcement_id}}/deactivate",
+              "host": ["{{base_url}}"],
+              "path": [
+                "api",
+                "announcements",
+                "{{announcement_id}}",
+                "deactivate"
+              ]
+            },
+            "description": "Deactivate announcement (hide from public view)."
+          }
+        },
+        {
+          "name": "Activate Announcement",
+          "request": {
+            "method": "PATCH",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{access_token}}"
+              }
+            ],
+            "url": {
+              "raw": "{{base_url}}/api/announcements/{{announcement_id}}/activate",
+              "host": ["{{base_url}}"],
+              "path": [
+                "api",
+                "announcements",
+                "{{announcement_id}}",
+                "activate"
+              ]
+            },
+            "description": "Activate announcement (make visible to public)."
+          }
+        },
+        {
+          "name": "Delete Announcement",
+          "request": {
+            "method": "DELETE",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{access_token}}"
+              }
+            ],
+            "url": {
+              "raw": "{{base_url}}/api/announcements/{{announcement_id}}",
+              "host": ["{{base_url}}"],
+              "path": ["api", "announcements", "{{announcement_id}}"]
+            },
+            "description": "Delete announcement permanently (owner only)."
+          }
+        },
+        {
+          "name": "Get Recent Announcements",
+          "request": {
+            "method": "GET",
+            "url": {
+              "raw": "{{base_url}}/api/announcements/recent?limit=5",
+              "host": ["{{base_url}}"],
+              "path": ["api", "announcements", "recent"],
+              "query": [
+                {
+                  "key": "limit",
+                  "value": "5",
+                  "description": "Number of recent announcements to get"
+                }
+              ]
+            },
+            "description": "Get most recent announcements."
+          }
+        },
+        {
+          "name": "Get Announcement Statistics",
+          "request": {
+            "method": "GET",
+            "url": {
+              "raw": "{{base_url}}/api/announcements/stats",
+              "host": ["{{base_url}}"],
+              "path": ["api", "announcements", "stats"]
+            },
+            "description": "Get announcement counts and statistics for dashboard."
           }
         }
       ]
@@ -693,7 +908,12 @@
             "url": {
               "raw": "{{base_url}}/api/conversations/{{conversation_id}}/messages",
               "host": ["{{base_url}}"],
-              "path": ["api", "conversations", "{{conversation_id}}", "messages"]
+              "path": [
+                "api",
+                "conversations",
+                "{{conversation_id}}",
+                "messages"
+              ]
             },
             "description": "Get messages in specific conversation."
           }


### PR DESCRIPTION
- Add Announcement entity with type/status enums and GPS location 
- Create AnnouncementRepository with search queries
- Implement AnnouncementService with CRUD operations and validation
- Add AnnouncementController with 11 REST endpoints
- Create AnnouncementMapper and DTOs for data transfer
- Add text search, filtering, and statistics capabilities
- Update JWT service to include userId in token claims
- Update Postman collection with all announcement endpoints
- All endpoints tested and working